### PR TITLE
FIX broken link to img and 404 calls for sidebar

### DIFF
--- a/android/quick-start.md
+++ b/android/quick-start.md
@@ -53,6 +53,6 @@ Few seconds after the `show` method is called, an intercepting pop-up should app
 
 <img 
     alt="UserZoom intercept example"
-    src="/img/intercept-example.png"
+    src="../img/intercept-example.png"
     style="width: 50%; display:block; margin: auto;"
 />

--- a/index.html
+++ b/index.html
@@ -25,10 +25,13 @@
   <div id="app"></div>
   <script>
     window.$docsify = {
-    name: ('<a href="./"><img src="./zooie.svg"/></a>'),
-		loadSidebar: true,
-		maxLevel: 4,
-		subMaxLevel: 4
+      name: ('<a href="./"><img src="./zooie.svg"/></a>'),
+      loadSidebar: true,
+      maxLevel: 4,
+      subMaxLevel: 4,
+      alias: {
+        '/.*/_sidebar.md': '/_sidebar.md'
+      }
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>

--- a/ios/quick-start.md
+++ b/ios/quick-start.md
@@ -51,7 +51,7 @@ Few seconds after the `show` method is called, an intercepting pop-up should app
 
 <img 
     alt="UserZoom intercept example"
-    src="/img/intercept-example.png"
+    src="../img/intercept-example.png"
     style="width: 50%; display:block; margin: auto;"
 />
 


### PR DESCRIPTION
Fix some minor issues spotted after deploying the latest SDK refactor:
- Path to the `intercept-example.png` has been changed from absolute to relative as GitHub bundles all static file to one main catalogue `UserZoomSDK-docs`;
- Added an alias for `_sidebar.md` to the docsify configuration to avoid failing 404 HTTP calls for nested sidebars.